### PR TITLE
Add buffered player movement

### DIFF
--- a/Assets/Examples/PipePushParadise/ppp.unity
+++ b/Assets/Examples/PipePushParadise/ppp.unity
@@ -3815,6 +3815,11 @@ PrefabInstance:
       propertyPath: fallTime
       value: 0.05
       objectReference: {fileID: 0}
+    - target: {fileID: 877372581326712350, guid: 077771e453471a74990da57584a62930,
+        type: 3}
+      propertyPath: moveBufferSpeedupFactor
+      value: 0.5
+      objectReference: {fileID: 0}
     - target: {fileID: 877372581326712351, guid: 077771e453471a74990da57584a62930,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Examples/Sokoban/sokoban.unity
+++ b/Assets/Examples/Sokoban/sokoban.unity
@@ -4041,6 +4041,11 @@ PrefabInstance:
       propertyPath: fallTime
       value: 0.05
       objectReference: {fileID: 0}
+    - target: {fileID: 877372581326712350, guid: 077771e453471a74990da57584a62930,
+        type: 3}
+      propertyPath: moveBufferSpeedupFactor
+      value: 0.5
+      objectReference: {fileID: 0}
     - target: {fileID: 877372581326712351, guid: 077771e453471a74990da57584a62930,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/Example.unity
+++ b/Assets/Scenes/Example.unity
@@ -11273,7 +11273,12 @@ PrefabInstance:
     - target: {fileID: 877372581326712350, guid: 077771e453471a74990da57584a62930,
         type: 3}
       propertyPath: fallTime
-      value: 0.05
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 877372581326712350, guid: 077771e453471a74990da57584a62930,
+        type: 3}
+      propertyPath: moveBufferSpeedupFactor
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 877372581326712351, guid: 077771e453471a74990da57584a62930,
         type: 3}

--- a/Assets/Scripts/Game.cs
+++ b/Assets/Scripts/Game.cs
@@ -29,6 +29,7 @@ public class Game : MonoBehaviour {
 
 	public float moveTime = 0.18f; // time it takes to move 1 unit
 	public float fallTime = 0.1f; // time it takes to fall 1 unit
+	public float moveBufferSpeedupFactor = 0.5f; //degree of speedup due to buffered inputs
 
 	private int movingCount = 0;
 	private List<List<MoverPos>> PlannedMoves = new List<List<MoverPos>>();
@@ -81,6 +82,7 @@ public class Game : MonoBehaviour {
 
 	public void Refresh() {
 		movingCount = 0;
+		Player.instance.ClearInputBuffer();
 		PlannedMoves.Clear();
 		foreach (var mover in movers)
 			mover.Stop();
@@ -210,7 +212,18 @@ public class Game : MonoBehaviour {
 			return;
 		}
 
-		var dur = falling ? fallTime : moveTime;
+		if (falling) { Player.instance.ClearInputBuffer(); }
+
+		float dur;
+		if (falling)
+		{
+			dur = fallTime;
+		}
+		else
+		{
+			dur = moveTime / (Player.instance.InputBuffer.Count()*moveBufferSpeedupFactor + 1); // increase the animation speed when moves are buffered
+		}
+
 		foreach (var move in PlannedMoves[0])
 		{
 			if (move.Pos == move.m.Pos()) continue;
@@ -226,7 +239,7 @@ public class Game : MonoBehaviour {
 			// We assume that all move cycles after the first are falls.
 			// This won't be true for all games (eg those with conveyors,
 			// slippery ice, etc), so you'll need to adjust this.
-			StartMoveCycle(false);
+			StartMoveCycle(true);
 		}
 	}
 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,17 +1,28 @@
 ﻿using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
 
 public class Player : Mover {
 
 	public static Player instance { get; private set; }
 	Vector3Int direction = Vector3Int.zero;
 
+	float prevHorInput = 0;
+	float prevVerInput = 0;
+	
+	public List<Vector3Int> InputBuffer = new List<Vector3Int>();
+
 	void Awake() {
 		instance = this;
 	}
-	
-	void Update () {
-		if (CanInput()) {
-			CheckInput();
+
+	void Update() {
+		if (!Game.instance.holdingUndo)	{
+			BufferInput();
+		}
+
+		if (CanInput())	{
+			CheckBufferedInput();
 		}
 	}
 
@@ -19,34 +30,92 @@ public class Player : Mover {
 		return !Game.instance.isMoving && !Game.instance.holdingUndo;
 	}
 
-	public void CheckInput() {
+	public void ClearInputBuffer() {
+		InputBuffer.Clear();
+		prevHorInput = 0;
+		prevVerInput = 0;
+		direction = Vector3Int.zero;
+	}
+
+	public void BufferInput() {
+
+		float newHor = Input.GetAxisRaw("Horizontal");
+		float newVer = Input.GetAxisRaw("Vertical");
+
+		bool shouldBufferInput =
+			(newHor != prevHorInput || newVer != prevVerInput) && //input is different from last time it was checked
+			!((newHor == 0 && newVer == prevVerInput) || (newVer == 0 && newHor == prevHorInput)); //the change isn't just due to releasing a key
+
+		Vector3Int dir = Vector3Int.zero;
+
+		if (InputBuffer.Count == 0)
+		{
+			if (shouldBufferInput || CanInput() ) {
+				dir = CalculateNewDirFromInput(direction);
+			}
+		}
+		else
+		{
+			if (shouldBufferInput) {
+				dir = CalculateNewDirFromInput(InputBuffer.Last());
+			}
+		}
+
+		if (dir != Vector3Int.zero)	{
+			InputBuffer.Add(dir);
+		}
+
+		prevHorInput = newHor;
+		prevVerInput = newVer;
+	}
+
+	public void CheckBufferedInput() {
+
+		if (InputBuffer.Count == 0) {
+			return;
+		}
+
+		direction = InputBuffer.First();
+		InputBuffer.RemoveAt(0);
+
+		if (TryPlanMove(direction))	{
+			Game.instance.MoveStart();
+		}
+
+	}
+
+	public Vector3Int CalculateNewDirFromInput(Vector3Int currentDir) {
 
 		float hor = Input.GetAxisRaw("Horizontal");
 		float ver = Input.GetAxisRaw("Vertical");
 
 		if (hor == 0 && ver == 0) {
-			return;
+			return Vector3Int.zero;
 		}
 
 		if (hor != 0 && ver != 0) {
-			if (direction == Vector3Int.right || direction == Vector3Int.left) {
+			if (currentDir == Vector3Int.right || currentDir == Vector3Int.left) {
 				hor = 0;
-			} else {
+			}
+			else {
 				ver = 0;
 			}
 		}
 
 		if (hor == 1) {
-			direction = Vector3Int.right;
-		} else if (hor == -1) { 
-			direction = Vector3Int.left;
-		} else if (ver == -1) {
-			direction = Vector3Int.down;
-		} else if (ver == 1) {
-			direction = Vector3Int.up;
+			return Vector3Int.right;
 		}
-
-		if (TryPlanMove(direction))
-			Game.instance.MoveStart();
+		else if (hor == -1) {
+			return Vector3Int.left;
+		}
+		else if (ver == -1) {
+			return Vector3Int.down;
+		}
+		else if (ver == 1) {
+			return Vector3Int.up;
+		}
+		
+		return Vector3Int.zero;
 	}
+
 }


### PR DESCRIPTION
Inputs are now buffered. When an input is made, a movement direction is added to a list, which is read from whenever a new turn can begin.
Buffered inputs speed up animations.
Falling clears the input buffer.

This input system relies on there being exactly one player in the scene.

This commit also fixes objects falling at move speed rather than fall speed.